### PR TITLE
Speed-up experiment using an array as buffer

### DIFF
--- a/erubi.gemspec
+++ b/erubi.gemspec
@@ -13,4 +13,5 @@ Gem::Specification.new do |s|
   s.files = %w(MIT-LICENSE CHANGELOG README.rdoc Rakefile) + Dir["{test,lib}/**/*.rb"]
   s.description = "Erubi is a ERB template engine for ruby. It is a simplified fork of Erubis"
   s.add_development_dependency "minitest"
+  s.add_development_dependency "benchmark-ips"
 end

--- a/lib/erubi.rb
+++ b/lib/erubi.rb
@@ -147,7 +147,12 @@ module Erubi
       src << "\n" unless src[RANGE_LAST] == "\n"
       add_postamble(postamble)
       src << "; ensure\n  #{bufvar} = __original_outvar\nend\n" if properties[:ensure]
-      src.freeze
+
+      if @src.is_a?(Array)
+        @src = @src.join
+      end
+
+      @src.freeze
       freeze
     end
 

--- a/test/bench.rb
+++ b/test/bench.rb
@@ -1,0 +1,41 @@
+unless defined?(TESTDIR)
+  TESTDIR = File.dirname(__FILE__)
+  LIBDIR  = TESTDIR == '.' ? '../lib' : File.dirname(TESTDIR) + '/lib'
+  $: << TESTDIR
+  $: << LIBDIR
+end
+
+require 'erubi'
+require 'erubi/capture_end'
+require 'benchmark/ips'
+
+TEMPLATE = "
+  <table>
+   <tbody>
+    <% i = 0
+       list.each_with_index do |item, i| %>
+    <tr>
+     <td><%= i+1 %></td>
+     <td><%== item %></td>
+    </tr>
+   <% end %>
+   </tbody>
+  </table>
+"
+
+Benchmark.ips do |x|
+  x.time = 5
+  x.warmup = 2
+
+  x.report("string") do
+    Erubi::Engine.new(TEMPLATE)
+  end
+
+  x.report("array") do |times|
+    Erubi::Engine.new(TEMPLATE, src: [])
+  end
+
+  x.compare!
+end
+
+


### PR DESCRIPTION
Appending content to an array instead of a string
seems to speed-up rendering of a small template by 3000x.

Looks to good to be true. Am I missing something? :)

```
Warming up --------------------------------------
              string     2.964k i/100ms
               array     2.955k i/100ms
Calculating -------------------------------------
              string     30.570k (±11.0%) i/s -    151.164k in
5.006935s
               array    103.274M (±22.5%) i/s -    422.819M in
4.941287s

Comparison:
               array: 103273902.7 i/s
              string:    30569.9 i/s - 3378.29x  slower
```